### PR TITLE
Don't fire `onOptionSelected` incorrectly

### DIFF
--- a/lib/typeahead/index.js
+++ b/lib/typeahead/index.js
@@ -231,9 +231,8 @@ var Typeahead = React.createClass({
   },
 
   _onEnter: function (event) {
-    console.log(this.state.showResults);
     var selection = this.getSelection();
-    if (!selection) {
+    if (!selection || !this.state.showResults) {
       return this.props.onKeyDown(event);
     }
     return this._onOptionSelected(selection, event);

--- a/lib/typeahead/index.js
+++ b/lib/typeahead/index.js
@@ -231,6 +231,7 @@ var Typeahead = React.createClass({
   },
 
   _onEnter: function (event) {
+    console.log(this.state.showResults);
     var selection = this.getSelection();
     if (!selection) {
       return this.props.onKeyDown(event);

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -244,6 +244,7 @@ var Typeahead = React.createClass({
   },
 
   _onEnter: function(event) {
+    console.log(this.state.showResults);
     var selection = this.getSelection();
     if (!selection) {
       return this.props.onKeyDown(event);

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -244,9 +244,8 @@ var Typeahead = React.createClass({
   },
 
   _onEnter: function(event) {
-    console.log(this.state.showResults);
     var selection = this.getSelection();
-    if (!selection) {
+    if (!selection || !this.state.showResults) {
       return this.props.onKeyDown(event);
     }
     return this._onOptionSelected(selection, event);


### PR DESCRIPTION
We should not fire `onOptionSelected` if we're not actually selecting something from the dropdown
